### PR TITLE
fix(docu): Change example for openwrt_network_bridge_vlanhost

### DIFF
--- a/roles/ansible_openwrtnetwork/README.md
+++ b/roles/ansible_openwrtnetwork/README.md
@@ -6,7 +6,7 @@
 You can define interfaces in ansible, either
 - per host via `openwrt_network_interfaceshost` 
 - per group via `openwrt_network_interfacesgroup`
-The same is avlid for 
+The same is valid for 
 - `openwrt_network_devices` and
 - `openwrt_network_bridge_vlan`
 
@@ -130,13 +130,13 @@ openwrt_network_deviceshost:
       - "eth3"
 ```
 
-In order to assign VLAN you use the 'openwrt_network_bridge_vlan' variable:
+In order to assign VLAN you use the 'openwrt_network_bridge_vlanhost' variable:
 * **t** is Tagged
 * **u** is untagged
 * **\*** is for primary VLAN ID
 
 ```yaml
-openwrt_network_bridge_vlan:
+openwrt_network_bridge_vlanhost:
   - device: "mainbridge"
     vlan: "5"
     vlaninfo: "Netz1"


### PR DESCRIPTION
The example now aligns with the merge logic in
`roles/ansible_openwrtnetwork/tasks/merge.yml`

Change `openwrt_network_bridge_vlan` to
`openwrt_network_bridge_vlanhost`.

---
Personal note:
Thanks for your nice work! Currently I am in the process of managing my OpenWRT x86 VM as code. I use your Ansible Playbook(s) for this. For now everything is working with OpenWRT `23.05`