### PR TITLE
Reworked `ansible_openwrtimagebuilder` role

### DIFF
--- a/roles/ansible_openwrtimagebuilder/tasks/build.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/build.yml
@@ -1,48 +1,89 @@
 ---
-- name: set kernel parameters for build
+- name: Set kernel parameters for build
   ansible.builtin.lineinfile:
     path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/.config"
     regexp: "^{{ item.name }}="
     line: "{{ item.name }}={{ item.value }}"
   loop: "{{ openwrt_imagebuilder_kernelvars }}"
   when: openwrt_imagebuilder_kernelvars is defined
+
 - name: List packages that will be in the image
-  debug:
+  ansible.builtin.debug:
     var: packages_install
+
 - name: List packages that will be remove in the image
-  debug:
+  ansible.builtin.debug:
     var: packages_remove
+
 - name: Convert imagebuilder packages into list
   ansible.builtin.set_fact:
-    packages_imagebuilder: "{{ ( packages_install + ( packages_remove | map('regex_replace', '^', '-'))) | join(packages_separator) }}"
-  when: packages_install is defined
-- name: Building info
-  debug:
-    msg: "Building with the following command: make image PACKAGES={{ packages_imagebuilder }} FILES={{ openwrt_imagebuilder_filesdir }}"
-  when: openwrt_imagebuilder_profile is not defined
-- name: Building info
-  debug:
-    msg: "Building with the following command: make image PACKAGES={{ packages_imagebuilder }} FILES={{ openwrt_imagebuilder_filesdir }} PROFILE={{ openwrt_imagebuilder_profile }}"
+    openwrt_imagebulder_make_packages: >-
+      PACKAGES="
+      {{ packages_install | default('') | join(' ') }}
+      {{ packages_remove | map('regex_replace', '^', '-') | join(' ') }}"
+  when: packages_install is defined or packages_remove is defined
+
+- name: Check if filesdir is defined
+  ansible.builtin.set_fact:
+    openwrt_imagebulder_make_filesdir: "FILES=\"{{ openwrt_imagebuilder_filesdir }}\""
+  when: openwrt_imagebuilder_filesdir is defined
+
+- name: Check if imagebuilder profile is defined
+  ansible.builtin.set_fact:
+    openwrt_imagebulder_make_profile: "PROFILE=\"{{ openwrt_imagebuilder_profile }}\""
   when: openwrt_imagebuilder_profile is defined
+
+- name: Check if there are services to be disabled
+  ansible.builtin.set_fact:
+    openwrt_imagebulder_make_services: "DISABLE_SERVICES=\"{{ openwrt_services_disabled | join(' ') }}\""
+  when: openwrt_services_disabled is defined
+
+- name: Create make command
+  ansible.builtin.set_fact:
+    openwrt_imagebuilder_make_image_command: >-
+      make image
+      {{ openwrt_imagebulder_make_packages | default("") }}
+      {{ openwrt_imagebulder_make_filesdir | default("") }}
+      {{ openwrt_imagebulder_make_profile | default("") }}
+      {{ openwrt_imagebulder_make_services | default("") }}
+    openwrt_imagebuilder_make_path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}"
+
+- name: Building info
+  ansible.builtin.debug:
+    msg: "Building with the following command: {{ make_image_command }}"
+
 - name: Create image
-  ansible.builtin.shell: make image PACKAGES="{{ packages_imagebuilder|default("") }}" FILES="{{ openwrt_imagebuilder_filesdir }}"
-  args:
-    chdir: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}"
-  when: openwrt_imagebuilder_profile is not defined
-- name: Create image with profile option
-  ansible.builtin.shell: make image PACKAGES="{{ packages_imagebuilder|default("") }}" FILES="{{ openwrt_imagebuilder_filesdir }}" PROFILE="{{ openwrt_imagebuilder_profile }}"
-  args:
-    chdir: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}"
-  when: openwrt_imagebuilder_profile is defined
-- name: compress and remove for user set path
+  ansible.builtin.command:
+    cmd: "{{ openwrt_imagebuilder_make_image_command }}"
+    chdir: "{{ openwrt_imagebuilder_make_path }}"
+  changed_when: true
+
+- name: Find the image
+  ansible.builtin.find:
+    paths: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/bin"
+    recurse: true
+    patterns: "*-sysupgrade.bin"
+  register: openwrt_imagebuilder_image
+
+- name: Store file name
+  ansible.builtin.set_fact:
+    openwrt_imagebuilder_image_name: "{{ openwrt_imagebuilder_image.files[0].path | basename }}"
+    openwrt_imagebuilder_image_path: "{{ openwrt_imagebuilder_image.files[0].path }}"
+
+- name: Print the image name
+  ansible.builtin.debug:
+    var: openwrt_imagebuilder_image_name
+
+- name: Copy the image to the output directory
+  ansible.builtin.copy:
+    src: "{{ openwrt_imagebuilder_image.files[0].path }}"
+    dest: "{{ openwrt_imagebuilder_outputdir }}/{{ inventory_hostname }}--{{ openwrt_imagebuilder_image_name }}"
+    remote_src: true
+    mode: '0644'
+
+- name: Compress and remove build directory
   community.general.archive:
     path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/bin"
-    dest: "{{ openwrt_imagebuilder_destinationpath }}/{{ inventory_hostname }}.tar.gz"
+    dest: "{{ openwrt_imagebuilder_destinationpath | default(openwrt_imagebuilder_outputdir) }}/{{ inventory_hostname }}.tar.gz"
     remove: true
-  when: openwrt_imagebuilder_destinationpath is defined
-- name: compress images and remove
-  community.general.archive:
-    path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/bin"
-    dest: "{{ openwrt_imagebuilder_outputdir }}/{{ inventory_hostname }}.tar.gz"
-    remove: true
-  when: not openwrt_imagebuilder_destinationpath is defined
+    mode: '0644'

--- a/roles/ansible_openwrtimagebuilder/tasks/build.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/build.yml
@@ -76,8 +76,8 @@
 
 - name: Copy the image to the output directory
   ansible.builtin.copy:
-    src: "{{ openwrt_imagebuilder_image.files[0].path }}"
-    dest: "{{ openwrt_imagebuilder_outputdir }}/{{ inventory_hostname }}--{{ openwrt_imagebuilder_image_name }}"
+    src: "{{ openwrt_imagebuilder_image_path }}"
+    dest: "{{ openwrt_imagebuilder_destinationpath | default(openwrt_imagebuilder_outputdir) }}/{{ inventory_hostname }}--{{ openwrt_imagebuilder_image_name }}"
     remote_src: true
     mode: '0644'
 

--- a/roles/ansible_openwrtimagebuilder/tasks/build.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/build.yml
@@ -50,7 +50,7 @@
 
 - name: Building info
   ansible.builtin.debug:
-    msg: "Building with the following command: {{ make_image_command }}"
+    msg: "Building with the following command: {{ openwrt_imagebuilder_make_image_command }}"
 
 - name: Create image
   ansible.builtin.command:
@@ -77,13 +77,13 @@
 - name: Copy the image to the output directory
   ansible.builtin.copy:
     src: "{{ openwrt_imagebuilder_image_path }}"
-    dest: "{{ openwrt_imagebuilder_destinationpath | default(openwrt_imagebuilder_outputdir) }}/{{ inventory_hostname }}--{{ openwrt_imagebuilder_image_name }}"
+    dest: "{{ openwrt_imagebuilder_outputdir }}/{{ inventory_hostname }}--{{ openwrt_imagebuilder_image_name }}"
     remote_src: true
     mode: '0644'
 
 - name: Compress and remove build directory
   community.general.archive:
     path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/bin"
-    dest: "{{ openwrt_imagebuilder_destinationpath | default(openwrt_imagebuilder_outputdir) }}/{{ inventory_hostname }}.tar.gz"
+    dest: "{{ openwrt_imagebuilder_outputdir }}/{{ inventory_hostname }}.tar.gz"
     remove: true
     mode: '0644'

--- a/roles/ansible_openwrtimagebuilder/tasks/build.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/build.yml
@@ -58,29 +58,6 @@
     chdir: "{{ openwrt_imagebuilder_make_path }}"
   changed_when: true
 
-- name: Find the image
-  ansible.builtin.find:
-    paths: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/bin"
-    recurse: true
-    patterns: "*-sysupgrade.bin"
-  register: openwrt_imagebuilder_image
-
-- name: Store file name
-  ansible.builtin.set_fact:
-    openwrt_imagebuilder_image_name: "{{ openwrt_imagebuilder_image.files[0].path | basename }}"
-    openwrt_imagebuilder_image_path: "{{ openwrt_imagebuilder_image.files[0].path }}"
-
-- name: Print the image name
-  ansible.builtin.debug:
-    var: openwrt_imagebuilder_image_name
-
-- name: Copy the image to the output directory
-  ansible.builtin.copy:
-    src: "{{ openwrt_imagebuilder_image_path }}"
-    dest: "{{ openwrt_imagebuilder_outputdir }}/{{ inventory_hostname }}--{{ openwrt_imagebuilder_image_name }}"
-    remote_src: true
-    mode: '0644'
-
 - name: Compress and remove build directory
   community.general.archive:
     path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}/bin"

--- a/roles/ansible_openwrtimagebuilder/tasks/main.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/main.yml
@@ -1,5 +1,2 @@
 ---
-#- name: run chosen openwrt roles
-#  ansible.builtin.include_role:
-#    name: "{{ item }}"
-#  loop: "{{ openwrt_imagebuilder_roles }}"
+# main tasks file for ansible_openwrtimagebuilder

--- a/roles/ansible_openwrtimagebuilder/tasks/prepare.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/prepare.yml
@@ -1,46 +1,66 @@
 ---
 # todo, install packages necessary for imagebuilder on building host, maybe with python venv?
 # tasks file for ansible_openwrtimagebuilder
-- name: make sure builddir exists
+- name: Make sure builddir exists
   ansible.builtin.file:
     path: "{{ openwrt_imagebuilder_builddir }}"
     state: directory
-- name: make sure outputdir exists
+    mode: "0755"
+
+- name: Make sure outputdir exists
   ansible.builtin.file:
     path: "{{ openwrt_imagebuilder_outputdir }}"
     state: directory
-- name: get filename from url
+    mode: "0755"
+
+- name: Get filename from url
   ansible.builtin.set_fact:
     openwrt_imagebuilder_filename: "{{ openwrt_imagebuilder_downloadurl | basename }}"
-- name: check if download is needed
+
+- name: Check if download is needed
   ansible.builtin.stat:
     path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_filename }}"
   register: downloaded_file
-- name: conditional download file
+
+- name: Conditional download file
   ansible.builtin.get_url:
     url: "{{ openwrt_imagebuilder_downloadurl }}"
     dest: "{{ openwrt_imagebuilder_builddir }}"
+    mode: "0755"
   when: not downloaded_file.stat.exists
-- name: extract imagebuilder
+
+- name: Extract imagebuilder
   ansible.builtin.unarchive:
     src: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_filename }}"
     list_files: true
     dest: "{{ openwrt_imagebuilder_builddir }}"
   register: openwrt_imagebuilder_extraction
-- name: get extracted folder name
+
+- name: Get extracted folder name
   ansible.builtin.set_fact:
     openwrt_imagebuilder_extractedfolder: "{{ openwrt_imagebuilder_extraction.files[0] }}"
-- name: remove old files dir if exist
-  ansible.builtin.file:
-    path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}{{ openwrt_imagebuilder_filesdir }}"
-    state: absent
-- name: create empty files dir
-  ansible.builtin.file:
-    path: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}{{ openwrt_imagebuilder_filesdir }}"
-    state: directory
-- name: set this files directory to use as openwrt deployroot for all compatible roles
+
+- name: Set full path to files directory
   ansible.builtin.set_fact:
-    "{{ item }}": "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}{{ openwrt_imagebuilder_filesdir }}/"
+    openwrt_imagebuilder_deployroot: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}{{ openwrt_imagebuilder_filesdir }}"
+
+- name: Remove old files dir if exist
+  ansible.builtin.file:
+    path: "{{ openwrt_imagebuilder_deployroot }}"
+    state: absent
+
+- name: Create empty files dir
+  ansible.builtin.file:
+    path: "{{ openwrt_imagebuilder_deployroot }}"
+    state: directory
+    mode: "0755"
+
+  # It should be only for backward compatibility,
+  # new roles should use openwrt_imagebuilder_deployroot
+  # for setting deployroot
+- name: Set this files directory to use as openwrt deployroot for all compatible roles
+  ansible.builtin.set_fact:
+    "{{ item }}": "{{ openwrt_imagebuilder_deployroot }}/"
   loop:
     - openwrt_acme_deployroot
     - openwrt_batmanadv_deployroot

--- a/roles/ansible_openwrtimagebuilder/tasks/prepare.yml
+++ b/roles/ansible_openwrtimagebuilder/tasks/prepare.yml
@@ -42,7 +42,7 @@
 
 - name: Set full path to files directory
   ansible.builtin.set_fact:
-    openwrt_imagebuilder_deployroot: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}{{ openwrt_imagebuilder_filesdir }}"
+    openwrt_imagebuilder_deployroot: "{{ openwrt_imagebuilder_builddir }}/{{ openwrt_imagebuilder_extractedfolder }}{{ openwrt_imagebuilder_filesdir }}/"
 
 - name: Remove old files dir if exist
   ansible.builtin.file:
@@ -60,7 +60,7 @@
   # for setting deployroot
 - name: Set this files directory to use as openwrt deployroot for all compatible roles
   ansible.builtin.set_fact:
-    "{{ item }}": "{{ openwrt_imagebuilder_deployroot }}/"
+    "{{ item }}": "{{ openwrt_imagebuilder_deployroot }}"
   loop:
     - openwrt_acme_deployroot
     - openwrt_batmanadv_deployroot
@@ -74,6 +74,5 @@
     - openwrt_services_deployroot
     - openwrt_system_deployroot
     - openwrt_uhttpd_deployroot
-    - openwrt_usteer_deployroot
     - openwrt_wireless_deployroot
     - system_users_setpassword_deployroot

--- a/roles/ansible_openwrtusteer/defaults/main.yml
+++ b/roles/ansible_openwrtusteer/defaults/main.yml
@@ -4,3 +4,4 @@ openwrt_usteer_config:
 openwrt_usteer_deployroot: "/"
 openwrt_usteer_deploypath: "{{ openwrt_usteer_deployroot }}etc/config"
 openwrt_usteer_deployfile: "usteer"
+openwrt_usteer_runimagebuilder: false

--- a/roles/ansible_openwrtusteer/tasks/main.yml
+++ b/roles/ansible_openwrtusteer/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 # tasks file for ansible_openwrtusteer
+- name: Detect imagebuilder
+  ansible.builtin.set_fact:
+    openwrt_usteer_deployroot: "{{ openwrt_imagebuilder_deployroot }}"
+    openwrt_usteer_runimagebuilder: true
+  when: openwrt_imagebuilder_deployroot is defined
+
+
 - name: Make sure deploypath is present
   ansible.builtin.file:
     path: "{{ openwrt_usteer_deploypath }}"
@@ -18,9 +25,9 @@
     packages_installimagebuilder: []
   when:
     - packages_installimagebuilder is not defined
-    - openwrt_usteer_runimagebuilder | default(false)
+    - openwrt_usteer_runimagebuilder
 
 - name: Merge role packages into packages_installimagebuilder
   ansible.builtin.set_fact:
     packages_installimagebuilder: "{{ packages_installimagebuilder + packages_installrole }}"
-  when: openwrt_usteer_runimagebuilder | default(false)
+  when: openwrt_usteer_runimagebuilder


### PR DESCRIPTION
* Add `DISABLE_SERVICES` to `make image` command
* Add `openwrt_imagebuilder_deployroot` variable, which roles can use to define their own `deployroot` values. \
  This approach offers a more flexible solution compared to adding each role-specific variable directly to this role. \
  Previously, introducing a new role required modifying the `ansible_openwrtimagebuilder` role. With `openwrt_imagebuilder_deployroot`, someone can create and integrate new roles independently, without requiring changes to the `ansible_openwrtimagebuilder` role.
* Add  sysupgrade files directly to output folder
* Refactor -> Fixes compliant with Ansible Lint.