### PR TITLE
ansible_users: Fix OpenWrt /bin/bash path

### DIFF
--- a/roles/ansible_users/vars/OpenWrt.yml
+++ b/roles/ansible_users/vars/OpenWrt.yml
@@ -5,7 +5,7 @@ system_users_additional_packages:
 shells:
   "zsh": "/usr/bin/zsh"
   "sh": "/bin/sh"
-  "bash": "in/bash"
+  "bash": "/bin/bash"
   "fish": "/usr/bin/fish"
   "false": "/bin/false"
 shellpackages:


### PR DESCRIPTION
Fixes a typo for `/bin/bash` path on OpenWrt