### PR TITLE
Fix interface ipaddr

### DIFF
--- a/roles/ansible_openwrtnetwork/templates/functions.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/functions.jinja2
@@ -460,7 +460,7 @@ config interface "{{ key }}"
 {% endif %}
 {% if value['ipaddr'] is defined %}
 {% for singleip in value['ipaddr'] %}
-	list ipaddr "{{ singleip }}"
+	option ipaddr "{{ singleip }}"
 {% endfor %}
 {% endif %}
 {% if value['ip6assign'] is defined %}


### PR DESCRIPTION
"list ipaddr" doesn't exist, but "option ipaddr" does.

See https://openwrt.org/docs/guide-user/network/network_configuration#example_configuration