### PR TITLE
openwrt: Fix formatting, typos, add masq6

### DIFF
--- a/roles/ansible_openwrtbabeld/templates/babeld.jinja2
+++ b/roles/ansible_openwrtbabeld/templates/babeld.jinja2
@@ -1,13 +1,13 @@
 config general
-        option ipv6_subtrees 'true'
-        option ubus_bindings 'true'
-        option random_id 'true'
-        option local_port '33123'
+	option ipv6_subtrees 'true'
+	option ubus_bindings 'true'
+	option random_id 'true'
+	option local_port '33123'
 
 {% if openwrt_babeld_interfaces is defined %}
 {% for interface in openwrt_babeld_interfaces %}
 config interface
-        option ifname "{{ interface['name'] }}"
+	option ifname "{{ interface['name'] }}"
 {% if interface['type'] is defined %}
 	option type "{{ interface['type'] }}"
 {% endif %}
@@ -22,7 +22,7 @@ config interface
 {% for filter in openwrt_babeld_filter %}
 config filter
 {% if  filter.type is defined %}
-        option type "{{ filter.type }}"
+	option type "{{ filter.type }}"
 {% endif %}
 {% if filter.action is defined %}
 	option action "{{ filter.action }}"

--- a/roles/ansible_openwrtbmx7/templates/bmx7.jinja2
+++ b/roles/ansible_openwrtbmx7/templates/bmx7.jinja2
@@ -1,7 +1,7 @@
 # Configuration distributed by Ansible
 config bmx7 "general"
 	option runtimeDir "/var/run/bmx7"
-        option trustedNodesDir "/etc/bmx7/trustedNodes"
+	option trustedNodesDir "/etc/bmx7/trustedNodes"
 
 # Plugins
 {% if openwrt_bmx7_plugin_sms_enabled is defined and openwrt_bmx7_plugin_sms_enabled %}

--- a/roles/ansible_openwrtdhcp/templates/dhcp.jinja2
+++ b/roles/ansible_openwrtdhcp/templates/dhcp.jinja2
@@ -4,7 +4,7 @@
 # Global dnsmasq configuration
 config dnsmasq
 {% if openwrt_dhcp_add_local_domain is defined %}
-	options add_local_domain "{{ openwrt_dhcp_add_local_domain }}"
+	option add_local_domain "{{ openwrt_dhcp_add_local_domain }}"
 {% endif %}
 {% if openwrt_dhcp_dnsmasq_add_local_hostname is defined %}
 	option add_local_hostname "{{ openwrt_dhcp_dnsmasq_add_local_hostname }}"

--- a/roles/ansible_openwrtdhcp/templates/functions.jinja2
+++ b/roles/ansible_openwrtdhcp/templates/functions.jinja2
@@ -1,116 +1,116 @@
 {% macro create_pools(listofpools) %}
 {% for pool in listofpools %}
 config dhcp "{{ pool['name'] }}"
-       option interface "{{ pool['interface'] }}"
+	option interface "{{ pool['interface'] }}"
 {% if pool['dhcp_option'] is defined %}
 {% for option in pool['dhcp_option'] %}
-       list dhcp_option "{{ option }}"
+	list dhcp_option "{{ option }}"
 {% endfor %}
 {% endif %}
 {% if pool['dhcp_option_force'] is defined %}
 {% for option in pool['dhcp_option_force'] %}
-       list dhcp_option_force "{{ option }}"
+	list dhcp_option_force "{{ option }}"
 {% endfor %}
 {% endif %}
 {% if pool['dynamicdhcp'] is defined %}
-       option dynamicdhcp "{{ pool['dynamicdhcp'] }}"
+	option dynamicdhcp "{{ pool['dynamicdhcp'] }}"
 {% endif %}
 {% if pool['force'] is defined %}
-       option force "{{ pool['force'] }}"
+	option force "{{ pool['force'] }}"
 {% endif %}
 {% if pool['ignore'] is defined %}
-       option ignore "{{ pool['ignore'] }}"
+	option ignore "{{ pool['ignore'] }}"
 {% endif %}
 {% if pool['dhcpv4'] is defined %}
-       option dhcpv4 "{{ pool['dhcpv4'] }}"
+	option dhcpv4 "{{ pool['dhcpv4'] }}"
 {% endif %}
 {% if pool['dhcpv6'] is defined %}
-       option dhcpv6 "{{ pool['dhcpv6'] }}"
+	option dhcpv6 "{{ pool['dhcpv6'] }}"
 {% endif %}
 {% if pool['dns'] is defined %}
 {% for dns in pool['dns'] %}
-       list dns "{{ dns }}"
+	list dns "{{ dns }}"
 {% endfor %}
 {% endif %}
 {% if pool['dns_service'] is defined %}
 	option dns_service "{{ pool['dns_service'] }}"
 {% endif %}
 {% if pool['ra'] is defined %}
-       option ra "{{ pool['ra'] }}"
+	option ra "{{ pool['ra'] }}"
 {% endif %}
 {% if pool['ra_default'] is defined %}
-       option ra_default "{{ pool['ra_default'] }}"
+	option ra_default "{{ pool['ra_default'] }}"
 {% endif %}
 {% if pool['ra_flags'] is defined %}
 {% for ra_flag in pool['ra_flags'] %}
-       list ra_flags "{{ ra_flag }}"
+	list ra_flags "{{ ra_flag }}"
 {% endfor %}
 {% endif %}
 {% if pool['ra_slaac'] is defined %}
-       option ra_slaac "{{ pool['ra_slaac'] }}"
+	option ra_slaac "{{ pool['ra_slaac'] }}"
 {% endif %}
 {% if pool['ra_management'] is defined %}
-       option ra_management "{{ pool['ra_management'] }}"
+	option ra_management "{{ pool['ra_management'] }}"
 {% endif %}
 {% if pool['ra_offlink'] is defined %}
-       option ra_offlink "{{ pool['ra_offlink'] }}"
+	option ra_offlink "{{ pool['ra_offlink'] }}"
 {% endif %}
 {% if pool['ra_preference'] is defined %}
-       option ra_preference "{{ pool['ra_preference'] }}"
+	option ra_preference "{{ pool['ra_preference'] }}"
 {% endif %}
 {% if pool['ra_mininterval'] is defined %}
-       option ra_mininterval "{{ pool['ra_mininterval'] }}"
+	option ra_mininterval "{{ pool['ra_mininterval'] }}"
 {% endif %}
 {% if pool['ra_maxinterval'] is defined %}
-       option ra_maxinterval "{{ pool['ra_maxinterval'] }}"
+	option ra_maxinterval "{{ pool['ra_maxinterval'] }}"
 {% endif %}
 {% if pool['ra_lifetime'] is defined %}
-       option ra_lifetime "{{ pool['ra_lifetime'] }}"
+	option ra_lifetime "{{ pool['ra_lifetime'] }}"
 {% endif %}
 {% if pool['ra_useleasetime'] is defined %}
-       option ra_useleasetime "{{ pool['ra_useleasetime'] }}"
+	option ra_useleasetime "{{ pool['ra_useleasetime'] }}"
 {% endif %}
 {% if pool['ra_hoplimit'] is defined %}
-       option ra_hoplimit "{{ pool['ra_hoplimit'] }}"
+	option ra_hoplimit "{{ pool['ra_hoplimit'] }}"
 {% endif %}
 {% if pool['ra_reachabletime'] is defined %}
-       option ra_reachabletime "{{ pool['ra_reachabletime'] }}"
+	option ra_reachabletime "{{ pool['ra_reachabletime'] }}"
 {% endif %}
 {% if pool['ra_retranstime'] is defined %}
-       option ra_retranstime "{{ pool['ra_retranstime'] }}"
+	option ra_retranstime "{{ pool['ra_retranstime'] }}"
 {% endif %}
 {% if pool['ra_mtu'] is defined %}
-       option ra_mtu "{{ pool['ra_mtu'] }}"
+	option ra_mtu "{{ pool['ra_mtu'] }}"
 {% endif %}
 {% if pool['ra_dns'] is defined %}
-       option ra_dns "{{ pool['ra_dns'] }}"
+	option ra_dns "{{ pool['ra_dns'] }}"
 {% endif %}
 {% if pool['ndp'] is defined %}
-       option ndp "{{ pool['ndp'] }}"
+	option ndp "{{ pool['ndp'] }}"
 {% endif %}
 {% if pool['ndproxy_routing'] is defined %}
-       option ndproxy_routing "{{ pool['ndproxy_routing'] }}"
+	option ndproxy_routing "{{ pool['ndproxy_routing'] }}"
 {% endif %}
 {% if pool['ndproxy_slave'] is defined %}
-       option ndproxy_slave "{{ pool['ndproxy_slave'] }}"
+	option ndproxy_slave "{{ pool['ndproxy_slave'] }}"
 {% endif %}
 {% if pool['master'] is defined %}
-       option master "{{ pool['master'] }}"
+	option master "{{ pool['master'] }}"
 {% endif %}
 {% if pool['leasetime'] is defined %}
-       option leasetime "{{ pool['leasetime'] | default('12h', true) }}"
+	option leasetime "{{ pool['leasetime'] | default('12h', true) }}"
 {% endif %}
 {% if pool['limit'] is defined %}
-       option limit "{{ pool['limit'] }}"
+	option limit "{{ pool['limit'] }}"
 {% endif %}
 {% if pool['networkid'] is defined %}
-       option networkid "{{ pool['networkid'] }}"
+	option networkid "{{ pool['networkid'] }}"
 {% endif %}
 {% if pool['start'] is defined %}
-       option start "{{ pool['start'] }}"
+	option start "{{ pool['start'] }}"
 {% endif %}
 {% if pool['instance'] is defined %}
-       option instance "{{ pool['instance'] }}"
+	option instance "{{ pool['instance'] }}"
 {% endif %}
 {% if pool['tag'] is defined %}
 {% for tag in pool['tag'] %}
@@ -119,7 +119,7 @@ config dhcp "{{ pool['name'] }}"
 {% endif %}
 {% if pool['domain'] is defined %}
 {% for domain in pool['domain'] %}
-       list domain "{{ domain }}"
+	list domain "{{ domain }}"
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/ansible_openwrtfirewall/templates/functions.jinja2
+++ b/roles/ansible_openwrtfirewall/templates/functions.jinja2
@@ -107,6 +107,9 @@ config zone
 {% if value['masq'] is defined %}
 	option masq "{{ value['masq'] }}"
 {% endif %}
+{% if value['masq6'] is defined %}
+	option masq6 "{{ value['masq6'] }}"
+{% endif %}
 {% if value['mtu_fix'] is defined %}
 	option mtu_fix "{{ value['mtu_fix'] }}"
 {% endif %}

--- a/roles/ansible_openwrtnetwork/templates/keepalived.j2
+++ b/roles/ansible_openwrtnetwork/templates/keepalived.j2
@@ -1,2 +1,2 @@
 config globals 'globals'
-        option alt_config_file  "/etc/keepalived/keepalived.conf"
+	option alt_config_file "/etc/keepalived/keepalived.conf"

--- a/roles/ansible_openwrtsystem/templates/system.jinja2
+++ b/roles/ansible_openwrtsystem/templates/system.jinja2
@@ -82,7 +82,7 @@ config system 'system'
 	option zram_comp_algo "{{ openwrt_system_system_zram_comp_algo }}"
 {% endif %}
 {% if openwrt_system_zram_size_mb is defined %}
-	option zram_size_mb "{{ openwrt_sytem_zram_size_mb }}"
+	option zram_size_mb "{{ openwrt_system_zram_size_mb }}"
 {% endif %}
 
 {% if openwrt_system_ntp_server is defined %}

--- a/roles/ansible_openwrttinyproxy/templates/tinyproxy.j2
+++ b/roles/ansible_openwrttinyproxy/templates/tinyproxy.j2
@@ -60,7 +60,7 @@ config tinyproxy
 {% endif %}
 {% if openwrt_tinyproxy_logfile is defined %}
 	option LogFile "{{ openwrt_tinyproxy_logfile }}"
-{% elif openwrt_tinyproxy_Syslog is defined %}
+{% elif openwrt_tinyproxy_syslog is defined %}
 	option Syslog "{{ openwrt_tinyproxy_syslog }}"
 {% else %}
 	option LogFile "/var/log/tinyproxy.log"

--- a/roles/ansible_openwrtwireless/templates/wireless.jinja2
+++ b/roles/ansible_openwrtwireless/templates/wireless.jinja2
@@ -262,7 +262,7 @@ config wifi-iface "{{ key }}"
 {% endif %}
 {% if value.hostapd_bss_options is defined %}
 {% for hostapd_bss_option in value.hostapd_bss_options %}
-	list "{{ hostapd_bss_option }}"
+	list hostapd_bss_options "{{ hostapd_bss_option }}"
 {% endfor %}
 {% endif %}
 {% if value.server is defined %}
@@ -363,7 +363,7 @@ config wifi-iface "{{ key }}"
 {% endif %}
 {% if value.wps_config is defined %}
 {% for wps_method in value.wps_config %}
-	list "{{ wps_method }}"
+	list wps_config "{{ wps_method }}"
 {% endfor %}
 {% endif %}
 {% if value.wps_device_name is defined %}


### PR DESCRIPTION
This makes the templates being rendered to uci config files consistent in using tabs everywhere (as is the uci default).

Also fixes typos in some openwrt roles.

Allows adding the `masq6` option to firewall zones.