### PR TITLE
check list emptiness with "length" instead of "truthy" 

### DIFF
--- a/roles/ansible_packages/tasks/4remove.yml
+++ b/roles/ansible_packages/tasks/4remove.yml
@@ -8,7 +8,7 @@
     name: "{{ packages_remove }}"
     state: absent
   when:
-    - packages_remove is truthy
+    - packages_remove | length > 0
     - ansible_distribution != 'OpenWrt'
 
 - name: "MMN Packages - Uninstalling packages OpenWrt"
@@ -17,5 +17,5 @@
     state: absent
     update_cache: true
   when:
-    - packages_remove is truthy
+    - packages_remove | length > 0
     - ansible_distribution == 'OpenWrt'

--- a/roles/ansible_packages/tasks/4remove.yml
+++ b/roles/ansible_packages/tasks/4remove.yml
@@ -8,7 +8,7 @@
     name: "{{ packages_remove }}"
     state: absent
   when:
-    - packages_remove | length > 0
+    - packages_remove | default([]) | length > 0
     - ansible_distribution != 'OpenWrt'
 
 - name: "MMN Packages - Uninstalling packages OpenWrt"
@@ -17,5 +17,5 @@
     state: absent
     update_cache: true
   when:
-    - packages_remove | length > 0
+    - packages_remove | default([]) | length > 0
     - ansible_distribution == 'OpenWrt'

--- a/roles/ansible_packages/tasks/5install.yml
+++ b/roles/ansible_packages/tasks/5install.yml
@@ -8,7 +8,7 @@
     name: "{{ packages_install }}"
     state: present
   when:
-    - packages_install is truthy
+    - packages_install | length > 0
     - ansible_distribution != 'OpenWrt'
 
 - name: "MMN Packages - Installing packages OpenWrt"
@@ -17,5 +17,5 @@
     state: present
     update_cache: true
   when:
-    - packages_install is truthy
+    - packages_install | length > 0
     - ansible_distribution == 'OpenWrt'

--- a/roles/ansible_packages/tasks/5install.yml
+++ b/roles/ansible_packages/tasks/5install.yml
@@ -8,7 +8,7 @@
     name: "{{ packages_install }}"
     state: present
   when:
-    - packages_install | length > 0
+    - packages_install | default([]) | length > 0
     - ansible_distribution != 'OpenWrt'
 
 - name: "MMN Packages - Installing packages OpenWrt"
@@ -17,5 +17,5 @@
     state: present
     update_cache: true
   when:
-    - packages_install | length > 0
+    - packages_install | default([]) | length > 0
     - ansible_distribution == 'OpenWrt'


### PR DESCRIPTION
to address ansible deprecation warning: Ansible 2.19 requires conditions to return an explicit boolean value:


```
  TASK [imp1sh.ansible_managemynetwork.ansible_packages : MMN Packages - Uninstalling packages non OpenWrt] ***                           
  [DEPRECATION WARNING]: Conditional result at location /usr/share/ansible/collec                                                         
  tions/ansible_collections/imp1sh/ansible_managemynetwork/roles/ansible_packages                                                         
  /tasks/4remove.yml 10:7 was of type 'list'. Conditional results should only be                                                          
  True or False. The result was interpreted as False. This feature will be                                                                
  removed in version 2.19. Deprecation warnings can be disabled by setting                                                                
  deprecation_warnings=False in ansible.cfg.
```