### PR TITLE
Fix for invalid `None` appearing in `/etc/config/network`

### DIFF
--- a/roles/ansible_openwrtnetwork/templates/network.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/network.jinja2
@@ -20,7 +20,7 @@ config globals "globals"
 {% endif %}
 
 # bridge_vlan devices
-{% if openwrt_network_bridge_vlan is defined %}
+{% if openwrt_network_bridge_vlan is defined and openwrt_network_bridge_vlan | length > 0 %}
 {{ functions.create_bridge_vlan(openwrt_network_bridge_vlan) }}
 {% endif %}
 
@@ -61,12 +61,12 @@ config dsl "dsl"
 {{ functions.create_staticroutes6(openwrt_network_staticroutes6) }}
 {% endif %}
 
-{% if openwrt_network_rules4 is defined %}
+{% if openwrt_network_rules4 is defined and openwrt_network_rules4 | length > 0 %}
 # IPv4 rules
 {{ functions.create_rules4(openwrt_network_rules4) }}
 {% endif %}
 
-{% if openwrt_network_rules6 is defined %}
+{% if openwrt_network_rules6 is defined and openwrt_network_rules6 | length > 0 %}
 # IPv6 rules
 {{ functions.create_rules6(openwrt_network_rules6) }}
 {% endif %}


### PR DESCRIPTION
If the user does not specify non-empty values for any of the following variables then `None` appears in the `/etc/config/network` file.

- `openwrt_network_rules4host`
- `openwrt_network_rules6host`
- `openwrt_network_bridge_vlanhost`

The `None` does not break the translation of the configuration by OpenWrt into the relevant service config files, but it does stop `uci` from parsing and using them.

Until this (or similar) patch is applied, this can be worked around with dummy values:

```yaml
openwrt_network_rules4host:
  - bodge4:

openwrt_network_rules6host:
  - bodge6:

openwrt_network_bridge_vlanhost:
  - device: eth0
    vlan: 1
```

Or fixed in place with:

```bash
sed -i 's/^None/#None/g' /etc/config/network
```