### PR TITLE
Replaced invalid 'None' with useful comments

### DIFF
--- a/roles/ansible_openwrtfirewall/templates/functions.jinja2
+++ b/roles/ansible_openwrtfirewall/templates/functions.jinja2
@@ -1,4 +1,7 @@
 {% macro create_redirects(allredirects) %}
+{% if allredirects | length == 0 %}
+# No redirects defined
+{% else %}
 {% for key, value in allredirects.items() %}
 config redirect
 	option name "{{ key }}"
@@ -91,6 +94,7 @@ config redirect
 	option hellper "{{ value['hellper'] }}"
 {% endif %}
 {% endfor %}
+{% endif %}
 {% endmacro %}
 
 {% macro create_zones(allzones) %}
@@ -152,6 +156,8 @@ config forwarding
 {% if forwarding['enabled'] is defined %}
 	option enabled "{{ forwarding['enabled'] }}"
 {% endif %}
+{% else %}
+# Ignoring forwarding from {{ forwarding['src'] }} to {{ forwarding['dest'] }} as one of the zones is not active
 {% endif %}
 {% endfor %}
 {% endmacro %}
@@ -236,6 +242,8 @@ config rule
 	option limit "{{ value['limit'] }}"
 {% endif %}
 	option target "{{ value['target'] }}"
+{% else %}
+# Ignoring rule {{ key }} as source or destination zone is not active
 {% endif %}
 {% endfor %}
 {% endmacro %}

--- a/roles/ansible_openwrtnetwork/templates/functions.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/functions.jinja2
@@ -106,6 +106,9 @@ config wireguard_{{ value['interface'] }}
 {% endmacro %}
 
 {% macro create_bridge_vlan(allbrvlan) %}
+{% if allbrvlan | length == 0 %}
+# No bridge-vlan devices defined
+{% else %}
 {% for bridgevlan in allbrvlan %}
 config bridge-vlan
 	option device "{{ bridgevlan.device }}"
@@ -119,6 +122,7 @@ config bridge-vlan
 {% endfor %}
 {% endif %}
 {% endfor %}
+{% endif %}
 {% endmacro %}
 
 {% macro create_devices(alldevices) %}
@@ -611,9 +615,17 @@ config rule6 '{{ key }}'
 {% endmacro %}
 
 {% macro create_rules4(allrules4) %}
+{% if allrules4 | length == 0 %}
+# No IPv4 rules defined
+{% else %}
 {{ create_rules(allrules4, 4)}}
+{% endif %}
 {% endmacro %}
 
 {% macro create_rules6(allrules6) %}
+{% if allrules6 | length == 0 %}
+# No IPv6 rules defined
+{% else %}
 {{ create_rules(allrules6, 6)}}
+{% endif %}
 {% endmacro %}


### PR DESCRIPTION
See [my other PR](https://github.com/imp1sh/ansible_managemynetwork/pull/36) which fixes the invalid `None` that can appear in the config files if some values are not defined/empty.

This is an alternative approach providing useful comments in place of the `None`s to help debugging.

It also addresses a similar problem in `/etc/config/firewall`.