### PR TITLE
ansible_openwrtdhcp: add filter_aaaa support to dnsmasq template

### DIFF
--- a/roles/ansible_openwrtdhcp/templates/dhcp.jinja2
+++ b/roles/ansible_openwrtdhcp/templates/dhcp.jinja2
@@ -76,6 +76,9 @@ config dnsmasq
 {% if openwrt_dhcp_dnsmasq_filterwin2k is defined %}
 	option filterwin2k "{{ openwrt_dhcp_dnsmasq_filterwin2k }}"
 {% endif %}
+{% if openwrt_dhcp_dnsmasq_filter_aaaa is defined %}
+	option filter_aaaa "{{ openwrt_dhcp_dnsmasq_filter_aaaa }}"
+{% endif %}
 {% if openwrt_dhcp_dnsmasq_fqdn is defined %}
 	option fqdn "{{ openwrt_dhcp_dnsmasq_fqdn }}"
 {% endif %}


### PR DESCRIPTION
filter_aaaa ([docs](https://openwrt.org/docs/guide-user/base-system/dhcp#all_options)) was introduced in OpenWRT 22.03 to strip AAAA records from DNS responses. Add the missing template block so openwrt_dhcp_dnsmasq_filter_aaaa is rendered into /etc/config/dhcp alongside the other dnsmasq options.