### PR TITLE
add support for "defaultroute" for static address interfaces

### DIFF
--- a/roles/ansible_openwrtnetwork/templates/functions.jinja2
+++ b/roles/ansible_openwrtnetwork/templates/functions.jinja2
@@ -502,6 +502,9 @@ config interface "{{ key }}"
 {% if value['metric'] is defined %}
 	option metric "{{ value['metric'] }}"
 {% endif %}
+{% if value['defaultroute'] is defined %}
+	option defaultroute "{{ value['defaultroute'] }}"
+{% endif %}
 	# CONFIG OPTIONS STATIC END
 {% endif %}
 {% if value['proto'] == "none" %}


### PR DESCRIPTION
option `defaultroute` in section

```jinja
{% if value['proto'] == "static" %}
	# CONFIG OPTIONS STATIC
```

was not handled. 

This adds a handler for `defaultroute`, so that one may ensure a given network interface will not set up a default route.